### PR TITLE
Allow use of Stylelint 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "md5": "2.3.0"
     },
     "peerDependencies": {
-        "stylelint": "^14.9.1"
+        "stylelint": ">=14.9.1"
     },
     "homepage": "https://github.com/ssivanatarajan/stylelint-group-selectors/blob/master/README.md",
     "repository": {


### PR DESCRIPTION
Modifies the peerDependency version to be `>=14.19.1`, allowing Stylelint 15 to be used.